### PR TITLE
:lock: axios 1.17.0 업그레이드 - Proxy-Authorization 헤더 주입 취약점 패치

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,6 +1140,18 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/alpinejs": {
             "version": "3.15.0",
             "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.0.tgz",
@@ -1218,13 +1230,14 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
             }
         },
@@ -1397,6 +1410,23 @@
             },
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/delayed-stream": {
@@ -1752,6 +1782,19 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -2099,6 +2142,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/nanoid": {
             "version": "3.3.11",


### PR DESCRIPTION
## 개요
Dependabot 보안 알림 [#44](https://github.com/nambak/price_search/security/dependabot/44) 조치.

`axios` 1.15.2 → **1.17.0** 업그레이드. 프로토타입 오염을 통한 Proxy-Authorization 헤더 주입 취약점(낮음 심각도)을 수정합니다. 패치 버전은 1.16.0 이상입니다.

## 변경 사항
- `package-lock.json` 업데이트 (axios 1.17.0)
- `package.json`은 `^1.15.2` 범위가 1.17.0을 포함하므로 변경 불필요

## 검증
- `npm audit` → `found 0 vulnerabilities` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)