### PR TITLE
:lock: axios 1.17.0 보안 업데이트 + CodeQL 워크플로 추가

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,15 +26,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # 매주 월요일 09:00 KST (00:00 UTC) 정기 스캔
+    - cron: '0 0 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL은 PHP를 지원하지 않으므로 JS/TS 프론트엔드만 분석한다.
+        language: [ 'javascript-typescript' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "dependencies": {
                 "@tailwindcss/vite": "^4.1.12",
                 "autoprefixer": "^10.4.20",
-                "axios": "^1.15.2",
+                "axios": "^1.17.0",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^2.0",
                 "tailwindcss": "^4.0.7",
@@ -1140,6 +1140,18 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/alpinejs": {
             "version": "3.15.0",
             "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.0.tgz",
@@ -1218,13 +1230,14 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
             }
         },
@@ -1397,6 +1410,23 @@
             },
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/delayed-stream": {
@@ -1752,6 +1782,19 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -2099,6 +2142,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/nanoid": {
             "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@tailwindcss/vite": "^4.1.12",
         "autoprefixer": "^10.4.20",
-        "axios": "^1.15.2",
+        "axios": "^1.17.0",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0",
         "tailwindcss": "^4.0.7",


### PR DESCRIPTION
## 개요
Dependabot 보안 경고 3건을 해결하고, JavaScript/TypeScript 보안 스캐닝용 CodeQL 워크플로를 추가합니다.

## 변경 사항

### 🔒 axios 보안 업데이트 (`1.15.2` → `1.17.0`)
이전 `1.15.2` 업데이트 이후 공개된 신규 취약점 3건은 `1.16.0`에서 패치되어, 1.15.2로는 해결되지 않던 항목입니다.

| 번호 | 심각도 | 내용 | GHSA |
|---|---|---|---|
| #46 | high | 쿠키 이름 인젝션을 통한 ReDoS | GHSA-hfxv-24rg-xrqf |
| #45 | high | 리소스 제한 없는 할당(DoS) | GHSA-777c-7fjr-54vf |
| #44 | low | 프로토타입 오염 통한 Proxy-Auth 헤더 인젝션 | GHSA-654m-c8p4-x5fp |

`npm audit` 결과 취약점 0건 확인.

### 👷 CodeQL 워크플로 추가
JS/TS 대상 보안 스캐닝 워크플로 신규 추가.

## 확인
- [x] `npm audit` → 0 vulnerabilities
- [ ] master 병합 후 Dependabot 경고 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)